### PR TITLE
Add custom Vault Authentication Path when using k8s login method

### DIFF
--- a/src/main/java/io/github/jopenlibs/vault/api/Auth.java
+++ b/src/main/java/io/github/jopenlibs/vault/api/Auth.java
@@ -992,11 +992,11 @@ public class Auth extends OperationsBase {
     }
 
     /**
-     * <p>Basic login operation to authenticate to an JWT backend.  Example usage:</p>
+     * <p>Basic login operation to authenticate to an JWT backend with custom authentication path.  Example usage:</p>
      *
      * <blockquote>
      * <pre>{@code
-     * final AuthResponse response = vault.auth().loginByJwt("kubernetes", "dev", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...");
+     * final AuthResponse response = vault.auth().loginByJwt("kubernetes", "dev", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...", "custom/path");
      *
      * final String token = response.getAuthClientToken();
      * }</pre>
@@ -1069,7 +1069,7 @@ public class Auth extends OperationsBase {
 
 
     /**
-     * Basic login operation to authenticate to an kubernetes backend. Example usage:
+     * Basic login operation to authenticate to a kubernetes backend. Example usage:
      *
      * <blockquote>
      *

--- a/src/main/java/io/github/jopenlibs/vault/api/Auth.java
+++ b/src/main/java/io/github/jopenlibs/vault/api/Auth.java
@@ -987,12 +987,39 @@ public class Auth extends OperationsBase {
     // TODO: Needs integration test coverage if possible
     public AuthResponse loginByJwt(final String provider, final String role, final String jwt)
             throws VaultException {
+
+        return loginByJwt(provider, role, jwt, "auth/" + provider);
+    }
+
+    /**
+     * <p>Basic login operation to authenticate to an JWT backend.  Example usage:</p>
+     *
+     * <blockquote>
+     * <pre>{@code
+     * final AuthResponse response = vault.auth().loginByJwt("kubernetes", "dev", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...");
+     *
+     * final String token = response.getAuthClientToken();
+     * }</pre>
+     * </blockquote>
+     *
+     * @param provider Provider of JWT token.
+     * @param role The gcp role used for authentication
+     * @param jwt The JWT token for the role
+     * @param authPath The Authentication Path for Vault
+     * @return The auth token, with additional response metadata
+     * @throws VaultException If any error occurs, or unexpected response received from Vault
+     */
+    // TODO: Needs integration test coverage if possible
+    public AuthResponse loginByJwt(final String provider, final String role, final String jwt,
+            String authPath)
+            throws VaultException {
+
         return retry(attempt -> {
             // HTTP request to Vault
             final String requestJson = Json.object().add("role", role).add("jwt", jwt)
                     .toString();
             final RestResponse restResponse = new Rest()
-                    .url(config.getAddress() + "/v1/auth/" + provider + "/login")
+                    .url(config.getAddress() + "/v1/" + authPath + "/login")
                     .header("X-Vault-Namespace", this.nameSpace)
                     .header("X-Vault-Request", "true")
                     .body(requestJson.getBytes(StandardCharsets.UTF_8))


### PR DESCRIPTION
Hi @jopenlibs,

Thanks for maintaining this fork so actively. You are doing a great work for the community :pray: 

This PR aims to solve the hardcoding authentication path for Vault. This is extracted from the [official doc](https://developer.hashicorp.com/vault/docs/auth/kubernetes#via-the-api)
```
The default endpoint is auth/kubernetes/login. If this auth method was enabled at a different path, use that value instead of kubernetes
```
This is related to another issue https://github.com/lensesio/secret-provider/issues/46 that I'm trying to fix ( and hopefully pin the vaul-java-driver dependencies to your fork :crossed_fingers: )

Do let me know if you have any comments/ feedback on this.