### PR TITLE
Upgrate gradle version to 7.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins{
 
 group 'io.github.jopenlibs'
 archivesBaseName = 'vault-java-driver'
-version '7.6.1'
+version '5.4.0'
 
 // This project is actually limited to Java 8 compatibility.  See below.
 sourceCompatibility = 9

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'checkstyle'
 
 group 'io.github.jopenlibs'
 archivesBaseName = 'vault-java-driver'
-version '5.4.0'
+version '7.6.1'
 
 // This project is actually limited to Java 8 compatibility.  See below.
 sourceCompatibility = 9
@@ -16,16 +16,16 @@ repositories {
 }
 
 dependencies {
-    testCompile('junit:junit:4.13.2')
-    testCompile('org.mockito:mockito-core:4.8.0')
-    testCompile('org.testcontainers:testcontainers:1.17.5')
-    testCompile('org.eclipse.jetty:jetty-server:11.0.12')
-    testCompile('org.slf4j:slf4j-api:2.0.3')
-    testCompile('org.bouncycastle:bcprov-jdk15on:1.70')
-    testCompile('org.bouncycastle:bcpkix-jdk15on:1.70')
-    testCompile('org.apache.commons:commons-io:1.3.2')
+    testImplementation('junit:junit:4.13.2')
+    testImplementation('org.mockito:mockito-core:4.8.0')
+    testImplementation('org.testcontainers:testcontainers:1.17.5')
+    testImplementation('org.eclipse.jetty:jetty-server:11.0.12')
+    testImplementation('org.slf4j:slf4j-api:2.0.3')
+    testImplementation('org.bouncycastle:bcprov-jdk15on:1.70')
+    testImplementation('org.bouncycastle:bcpkix-jdk15on:1.70')
+    testImplementation('org.apache.commons:commons-io:1.3.2')
 
-    testRuntime('org.slf4j:slf4j-simple:2.0.3')
+    testRuntimeOnly('org.slf4j:slf4j-simple:2.0.3')
 }
 
 // Beginning of Java 9 compatibility config
@@ -46,8 +46,9 @@ compileJava {
     options.compilerArgs = ['--release', '8']
 }
 
-compileJava.options.encoding = 'UTF-8'
-compileTestJava.options.encoding = 'UTF-8'
+tasks.withType(JavaCompile){
+    options.encoding = 'UTF-8'
+}
 
 task compileModuleInfoJava(type: JavaCompile) {
     classpath = files()
@@ -68,26 +69,18 @@ classes.dependsOn compileModuleInfoJava
 // End of Java 9 compatibility config
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
+    archiveClassifier = 'javadoc'
     from javadoc.destinationDir
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier = 'sources'
+    archiveClassifier = 'sources'
     from sourceSets.main.allSource
 }
 
 //
 // Separate unit tests from integration tests.  See: `src/test-integration/README.md`
 //
-
-configurations {
-    unitTestsCompile.extendsFrom testCompile
-    unitTestsRuntime.extendsFrom testRuntime
-    integrationTestsCompile.extendsFrom testCompile
-    integrationTestsRuntime.extendsFrom testRuntime
-}
-
 sourceSets {
     unitTests {
         compileClasspath += main.output + test.output
@@ -102,9 +95,19 @@ sourceSets {
     }
 }
 
-task unitTest(type: Test) {
+configurations {
+    unitTestsImplementation.extendsFrom testImplementation
+    unitTestsRuntimeOnly.extendsFrom testRuntimeOnly
+    integrationTestsImplementation.extendsFrom testImplementation
+    integrationTestsRuntimeOnly.extendsFrom testRuntimeOnly
+}
+
+tasks.named('test') {
+    useJUnit()
+
     testClassesDirs = sourceSets.unitTests.output.classesDirs
     classpath = sourceSets.unitTests.runtimeClasspath
+
     testLogging {
         events "passed", "skipped", "failed"
     }
@@ -113,15 +116,22 @@ task unitTest(type: Test) {
     reports.junitXml.enabled = true
 }
 
-task integrationTest(type: Test) {
+def integrationTestTask = tasks.register('integrationTest', Test) {
+    useJUnit()
+
     testClassesDirs = sourceSets.integrationTests.output.classesDirs
     classpath = sourceSets.integrationTests.runtimeClasspath
+
     testLogging {
         events "passed", "skipped", "failed"
     }
 
     reports.html.enabled = false
     reports.junitXml.enabled = true
+}
+
+tasks.named('check') {
+    dependsOn(integrationTestTask)
 }
 
 //

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,10 @@
-apply plugin: 'java'
-apply plugin: 'maven'
-apply plugin: 'signing'
-apply plugin: 'checkstyle'
+plugins{
+    id 'java-library'
+    id 'signing'
+    id 'checkstyle'
+    id 'maven-publish'
+}
+
 
 group 'io.github.jopenlibs'
 archivesBaseName = 'vault-java-driver'
@@ -46,11 +49,11 @@ compileJava {
     options.compilerArgs = ['--release', '8']
 }
 
-tasks.withType(JavaCompile){
+tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'
 }
 
-task compileModuleInfoJava(type: JavaCompile) {
+tasks.register('compileModuleInfoJava', JavaCompile) {
     classpath = files()
     source = 'src/main/java/module-info.java'
     destinationDir = compileJava.destinationDir
@@ -68,13 +71,15 @@ compileModuleInfoJava.dependsOn compileJava
 classes.dependsOn compileModuleInfoJava
 // End of Java 9 compatibility config
 
-task javadocJar(type: Jar, dependsOn: javadoc) {
-    archiveClassifier = 'javadoc'
+tasks.register('javadocJar', Jar) {
+    dependsOn tasks.named("javadoc")
+    archiveClassifier.set('javadoc')
     from javadoc.destinationDir
 }
 
-task sourcesJar(type: Jar, dependsOn: classes) {
-    archiveClassifier = 'sources'
+tasks.register('sourcesJar', Jar) {
+    dependsOn tasks.named("classes")
+    archiveClassifier.set('sources')
     from sourceSets.main.allSource
 }
 
@@ -104,10 +109,8 @@ configurations {
 
 tasks.named('test') {
     useJUnit()
-
     testClassesDirs = sourceSets.unitTests.output.classesDirs
     classpath = sourceSets.unitTests.runtimeClasspath
-
     testLogging {
         events "passed", "skipped", "failed"
     }
@@ -118,20 +121,14 @@ tasks.named('test') {
 
 def integrationTestTask = tasks.register('integrationTest', Test) {
     useJUnit()
-
     testClassesDirs = sourceSets.integrationTests.output.classesDirs
     classpath = sourceSets.integrationTests.runtimeClasspath
-
     testLogging {
         events "passed", "skipped", "failed"
     }
 
     reports.html.enabled = false
     reports.junitXml.enabled = true
-}
-
-tasks.named('check') {
-    dependsOn(integrationTestTask)
 }
 
 //
@@ -155,74 +152,84 @@ artifacts {
 }
 
 if (hasProperty("publish")) {
-    signing {
-        sign configurations.archives
-    }
 
-    uploadArchives {
-        repositories {
-            mavenDeployer {
-                beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+    publishing {
+        publications {
+            mavenJava(MavenPublication) {
+                artifactId = 'vault-java-driver'
+                from components.java
 
-                repository(url: "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/") {
-                    authentication(userName: ossrhUsername, password: ossrhPassword)
-                }
-
-                snapshotRepository(url: "https://s01.oss.sonatype.org/content/repositories/snapshots/") {
-                    authentication(userName: ossrhUsername, password: ossrhPassword)
-                }
-
-                pom.project {
-                    name 'vault-java-driver'
-                    packaging 'jar'
-                    // optionally artifactId can be defined here
-                    description 'Zero-dependency Java client for HashiCorp\'s Vault'
-                    url 'https://github.com/jopenlibs/vault-java-driver'
+                pom {
+                    name = 'vault-java-driver'
+                    packaging = 'jar'
+                    description = 'Zero-dependency Java client for HashiCorp\'s Vault'
+                    url = 'https://github.com/jopenlibs/vault-java-driver'
 
                     scm {
-                        connection 'https://github.com/jopenlibs/vault-java-driver.git'
-                        developerConnection 'https://github.com/jopenlibs/vault-java-driver.git'
-                        url 'https://github.com/jopenlibs/vault-java-driver'
+                        connection = 'https://github.com/jopenlibs/vault-java-driver.git'
+                        developerConnection = 'https://github.com/jopenlibs/vault-java-driver.git'
+                        url = 'https://github.com/jopenlibs/vault-java-driver'
                     }
 
                     licenses {
                         license {
-                            name 'MIT'
-                            url 'https://github.com/jopenlibs/vault-java-driver/blob/master/README.md#license'
+                            name = 'MIT'
+                            url = 'https://github.com/jopenlibs/vault-java-driver/blob/master/README.md#license'
                         }
                     }
 
                     developers {
                         [
-                                developer {
-                                    id 'steve-perkins'
-                                    name 'Steve Perkins'
-                                    email 'steve@steveperkins.com'
-                                },
-                                developer {
-                                    id 'steve-perkins-bc'
-                                    name 'Steve Perkins'
-                                    email 'steve.perkins@bettercloud.com'
-                                },
-                                developer {
-                                    id 'jarrodcodes'
-                                    name 'Jarrod Young'
-                                    email 'jarrodsy@gmail.com'
-                                },
-                                developer {
-                                    id 'tledkov'
-                                    name 'Taras Ledkov'
-                                    email 'tledkov@apache.org'
-                                },
-                                developer {
-                                    id 'henryx'
-                                    name 'Enrico Bianchi'
-                                    email 'enrico.bianchi@gmail.com'
-                                }
+                            developer {
+                                id = 'steve-perkins'
+                                name = 'Steve Perkins'
+                                email = 'steve@steveperkins.com'
+                            },
+                            developer {
+                                id = 'steve-perkins-bc'
+                                name = 'Steve Perkins'
+                                email = 'steve.perkins@bettercloud.com'
+                            },
+                            developer {
+                                id = 'jarrodcodes'
+                                name = 'Jarrod Young'
+                                email = 'jarrodsy@gmail.com'
+                            },
+                            developer {
+                                id = 'tledkov'
+                                name = 'Taras Ledkov'
+                                email = 'tledkov@apache.org'
+                            },
+                            developer {
+                                id = 'henryx'
+                                name = 'Enrico Bianchi'
+                                email = 'enrico.bianchi@gmail.com'
+                            }
                         ]
                     }
                 }
             }
+        }
+        repositories {
+            maven {
+                credentials {
+                    username "$ossrhUsername"
+                    password "$ossrhPassword"
+                }
+                def releasesRepoUrl = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+                def snapshotsRepoUrl = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
+                url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+            }
+        }
+    }
+
+    signing {
+        sign publishing.publications.mavenJava
+    }
+
+    javadoc {
+        if(JavaVersion.current().isJava9Compatible()) {
+            options.addBooleanOption('html5', true)
         }
     }
 }


### PR DESCRIPTION
Update gradle version from 5.4.0 to 7.6.1   🚀 
Remove deprecated APIs and replace them (see [doc](https://docs.gradle.org/current/userguide/upgrading_version_6.html) for details):

- [x] change testCompile to testImplementation
- [x] apply syntax for plugins
- [x] replace task classifier with archiveClassifier (see  [here](https://docs.gradle.org/7.6/dsl/org.gradle.api.tasks.bundling.Jar.html#org.gradle.api.tasks.bundling.Jar:classifier))
- [x] test tasks and configuration (see [here](https://docs.gradle.org/7.3/userguide/java_testing.html))
- [x] replace maven plugin with maven-publish plugin (see [here](https://docs.gradle.org/7.6/userguide/publishing_maven.html#publishing_maven))