### PR TITLE
add possibility to pass preconfigured http client to reuse http/tls resources for consequent requests

### DIFF
--- a/src/main/java/io/github/jopenlibs/vault/VaultConfig.java
+++ b/src/main/java/io/github/jopenlibs/vault/VaultConfig.java
@@ -1,6 +1,7 @@
 package io.github.jopenlibs.vault;
 
 import java.io.Serializable;
+import java.net.http.HttpClient;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -43,6 +44,7 @@ public class VaultConfig implements Serializable {
     private Integer globalEngineVersion;
     private String nameSpace;
     private EnvironmentLoader environmentLoader;
+    private HttpClient httpClient;
 
     /**
      * <p>The code used to load environment variables is encapsulated here, so that a mock version
@@ -279,6 +281,19 @@ public class VaultConfig implements Serializable {
     }
 
     /**
+     * <p>Set a preconfigured HttpClient instance to use by REST API calls. This allows to reuse
+     * http resources (connections, worker threads) between calls. If a preconfigured HttpClient is specified, then
+     * sslConfig and openTimeout values passed to VaultConfig are ignored.
+     *
+     * @param httpClient preconfigured http client instance
+     * @return VaultConfig
+     */
+    public VaultConfig httpClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
+        return this;
+    }
+
+    /**
      * <p>Sets the maximum number of times that an API operation will retry upon failure.</p>
      *
      * <p>This method is not meant to be called from application-level code outside of this package
@@ -317,7 +332,6 @@ public class VaultConfig implements Serializable {
     void setEngineVersion(final Integer engineVersion) {
         this.globalEngineVersion = engineVersion;
     }
-
 
     /**
      * <p>This is the terminating method in the builder pattern.  The method that validates all of
@@ -413,5 +427,9 @@ public class VaultConfig implements Serializable {
 
     public int getPrefixPathDepth() {
         return prefixPathDepth;
+    }
+
+    public HttpClient getHttpClient() {
+        return httpClient;
     }
 }

--- a/src/main/java/io/github/jopenlibs/vault/api/Auth.java
+++ b/src/main/java/io/github/jopenlibs/vault/api/Auth.java
@@ -11,7 +11,6 @@ import io.github.jopenlibs.vault.response.LogicalResponse;
 import io.github.jopenlibs.vault.response.LookupResponse;
 import io.github.jopenlibs.vault.response.UnwrapResponse;
 import io.github.jopenlibs.vault.response.WrapResponse;
-import io.github.jopenlibs.vault.rest.Rest;
 import io.github.jopenlibs.vault.rest.RestResponse;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
@@ -376,7 +375,7 @@ public class Auth extends OperationsBase {
             final String url = urlBuilder.toString();
 
             // HTTP request to Vault
-            final RestResponse restResponse = new Rest()//NOPMD
+            final RestResponse restResponse = getRest()//NOPMD
                     .url(url)
                     .header("X-Vault-Token", config.getToken())
                     .header("X-Vault-Namespace", this.nameSpace)
@@ -437,7 +436,7 @@ public class Auth extends OperationsBase {
             // HTTP request to Vault
             final String requestJson = Json.object().add("app_id", appId).add("user_id", userId)
                     .toString();
-            final RestResponse restResponse = new Rest()//NOPMD
+            final RestResponse restResponse = getRest()//NOPMD
                     .url(config.getAddress() + "/v1/auth/" + path)
                     .header("X-Vault-Namespace", this.nameSpace)
                     .body(requestJson.getBytes(StandardCharsets.UTF_8))
@@ -525,7 +524,7 @@ public class Auth extends OperationsBase {
             // HTTP request to Vault
             final String requestJson = Json.object().add("role_id", roleId)
                     .add("secret_id", secretId).toString();
-            final RestResponse restResponse = new Rest()//NOPMD
+            final RestResponse restResponse = getRest()//NOPMD
                     .url(config.getAddress() + "/v1/auth/" + path + "/login")
                     .header("X-Vault-Namespace", this.nameSpace)
                     .header("X-Vault-Request", "true")
@@ -602,7 +601,7 @@ public class Auth extends OperationsBase {
         return retry(attempt -> {
             // HTTP request to Vault
             final String requestJson = Json.object().add("password", password).toString();
-            final RestResponse restResponse = new Rest()//NOPMD
+            final RestResponse restResponse = getRest()//NOPMD
                     .url(config.getAddress() + "/v1/auth/" + mount + "/login/" + username)
                     .header("X-Vault-Namespace", this.nameSpace)
                     .header("X-Vault-Request", "true")
@@ -721,7 +720,7 @@ public class Auth extends OperationsBase {
             }
             final String requestJson = request.toString();
 
-            final RestResponse restResponse = new Rest()//NOPMD
+            final RestResponse restResponse = getRest()//NOPMD
                     .url(config.getAddress() + "/v1/auth/" + mount + "/login")
                     .body(requestJson.getBytes(StandardCharsets.UTF_8))
                     .header("X-Vault-Namespace", this.nameSpace)
@@ -789,7 +788,7 @@ public class Auth extends OperationsBase {
                 request.add("nonce", nonce);
             }
             final String requestJson = request.toString();
-            final RestResponse restResponse = new Rest()//NOPMD
+            final RestResponse restResponse = getRest()//NOPMD
                     .url(config.getAddress() + "/v1/auth/" + mount + "/login")
                     .header("X-Vault-Namespace", this.nameSpace)
                     .header("X-Vault-Request", "true")
@@ -866,7 +865,7 @@ public class Auth extends OperationsBase {
                 request.add("role", role);
             }
             final String requestJson = request.toString();
-            final RestResponse restResponse = new Rest()//NOPMD
+            final RestResponse restResponse = getRest()//NOPMD
                     .url(config.getAddress() + "/v1/auth/" + mount + "/login")
                     .header("X-Vault-Namespace", this.nameSpace)
                     .header("X-Vault-Request", "true")
@@ -939,7 +938,7 @@ public class Auth extends OperationsBase {
         return retry(attempt -> {
             // HTTP request to Vault
             final String requestJson = Json.object().add("token", githubToken).toString();
-            final RestResponse restResponse = new Rest()//NOPMD
+            final RestResponse restResponse = getRest()//NOPMD
                     .url(config.getAddress() + "/v1/auth/" + mount + "/login")
                     .header("X-Vault-Namespace", this.nameSpace)
                     .header("X-Vault-Request", "true")
@@ -1020,7 +1019,7 @@ public class Auth extends OperationsBase {
             // HTTP request to Vault
             final String requestJson = Json.object().add("role", role).add("jwt", jwt)
                     .toString();
-            final RestResponse restResponse = new Rest()
+            final RestResponse restResponse = getRest()
                     .url(config.getAddress() + "/v1/" + authPath + "/login")
                     .header("X-Vault-Namespace", this.nameSpace)
                     .header("X-Vault-Request", "true")
@@ -1179,7 +1178,7 @@ public class Auth extends OperationsBase {
         final String mount = certAuthMount != null ? certAuthMount : "cert";
 
         return retry(attempt -> {
-            final RestResponse restResponse = new Rest()//NOPMD
+            final RestResponse restResponse = getRest()//NOPMD
                     .url(config.getAddress() + "/v1/auth/" + mount + "/login")
                     .header("X-Vault-Namespace", this.nameSpace)
                     .header("X-Vault-Request", "true")
@@ -1251,7 +1250,7 @@ public class Auth extends OperationsBase {
         return retry(attempt -> {
             // HTTP request to Vault
             final String requestJson = Json.object().add("increment", increment).toString();
-            final RestResponse restResponse = new Rest()//NOPMD
+            final RestResponse restResponse = getRest()//NOPMD
                     .url(config.getAddress() + "/v1/auth/" + mount + "/renew-self")
                     .header("X-Vault-Token", config.getToken())
                     .header("X-Vault-Namespace", this.nameSpace)
@@ -1307,7 +1306,7 @@ public class Auth extends OperationsBase {
 
         return retry(attempt -> {
             // HTTP request to Vault
-            final RestResponse restResponse = new Rest()//NOPMD
+            final RestResponse restResponse = getRest()//NOPMD
                     .url(config.getAddress() + "/v1/auth/" + mount + "/lookup-self")
                     .header("X-Vault-Token", config.getToken())
                     .header("X-Vault-Namespace", this.nameSpace)
@@ -1384,7 +1383,7 @@ public class Auth extends OperationsBase {
 
         retry(attempt -> {
             // HTTP request to Vault
-            final RestResponse restResponse = new Rest()//NOPMD
+            final RestResponse restResponse = getRest()//NOPMD
                     .url(config.getAddress() + "/v1/auth/" + mount + "/revoke-self")
                     .header("X-Vault-Token", config.getToken())
                     .header("X-Vault-Namespace", this.nameSpace)

--- a/src/main/java/io/github/jopenlibs/vault/api/Debug.java
+++ b/src/main/java/io/github/jopenlibs/vault/api/Debug.java
@@ -94,7 +94,7 @@ public class Debug extends OperationsBase {
 
         return retry(attempt -> {
             // Build an HTTP request for Vault
-            final Rest rest = new Rest()//NOPMD
+            final Rest rest = getRest()//NOPMD
                     .url(config.getAddress() + "/v1/" + path)
                     .header("X-Vault-Token", config.getToken())
                     .header("X-Vault-Namespace", this.nameSpace)

--- a/src/main/java/io/github/jopenlibs/vault/api/Logical.java
+++ b/src/main/java/io/github/jopenlibs/vault/api/Logical.java
@@ -6,7 +6,6 @@ import io.github.jopenlibs.vault.json.Json;
 import io.github.jopenlibs.vault.json.JsonObject;
 import io.github.jopenlibs.vault.json.JsonValue;
 import io.github.jopenlibs.vault.response.LogicalResponse;
-import io.github.jopenlibs.vault.rest.Rest;
 import io.github.jopenlibs.vault.rest.RestResponse;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -85,7 +84,7 @@ public class Logical extends OperationsBase {
             throws VaultException {
         return retry(attempt -> {
             // Make an HTTP request to Vault
-            final RestResponse restResponse = new Rest()//NOPMD
+            final RestResponse restResponse = getRest()//NOPMD
                     .url(config.getAddress() + "/v1/" + adjustPathForReadOrWrite(path,
                             config.getPrefixPathDepth(), operation))
                     .header("X-Vault-Token", config.getToken())
@@ -142,7 +141,7 @@ public class Logical extends OperationsBase {
                 attempt -> {
                     // Make an HTTP request to Vault
                     final RestResponse restResponse =
-                            new Rest() //NOPMD
+                            getRest() //NOPMD
                                     .url(config.getAddress() + "/v1/" + adjustPathForReadOrWrite(
                                             path,
                                             config.getPrefixPathDepth(), logicalOperations.readV2))
@@ -275,7 +274,7 @@ public class Logical extends OperationsBase {
                 }
             }
             // Make an HTTP request to Vault
-            final RestResponse restResponse = new Rest()//NOPMD
+            final RestResponse restResponse = getRest()//NOPMD
                     .url(config.getAddress() + "/v1/" + adjustPathForReadOrWrite(path,
                             config.getPrefixPathDepth(), operation))
                     .body(jsonObjectToWriteFromEngineVersion(operation, requestJson).toString()
@@ -368,7 +367,7 @@ public class Logical extends OperationsBase {
             throws VaultException {
         return retry(attempt -> {
             // Make an HTTP request to Vault
-            final RestResponse restResponse = new Rest()//NOPMD
+            final RestResponse restResponse = getRest()//NOPMD
                     .url(config.getAddress() + "/v1/" + adjustPathForDelete(path,
                             config.getPrefixPathDepth(), operation))
                     .header("X-Vault-Token", config.getToken())
@@ -418,7 +417,7 @@ public class Logical extends OperationsBase {
         return retry(attempt -> {
             // Make an HTTP request to Vault
             JsonObject versionsToDelete = new JsonObject().add("versions", versions);
-            final RestResponse restResponse = new Rest()//NOPMD
+            final RestResponse restResponse = getRest()//NOPMD
                     .url(config.getAddress() + "/v1/" + adjustPathForVersionDelete(path,
                             config.getPrefixPathDepth()))
                     .header("X-Vault-Token", config.getToken())
@@ -478,7 +477,7 @@ public class Logical extends OperationsBase {
         return retry(attempt -> {
             // Make an HTTP request to Vault
             JsonObject versionsToUnDelete = new JsonObject().add("versions", versions);
-            final RestResponse restResponse = new Rest() //NOPMD
+            final RestResponse restResponse = getRest() //NOPMD
                     .url(config.getAddress() + "/v1/" + adjustPathForVersionUnDelete(path,
                             config.getPrefixPathDepth()))
                     .header("X-Vault-Token", config.getToken())
@@ -525,7 +524,7 @@ public class Logical extends OperationsBase {
         return retry(attempt -> {
             // Make an HTTP request to Vault
             JsonObject versionsToDestroy = new JsonObject().add("versions", versions);
-            final RestResponse restResponse = new Rest()//NOPMD
+            final RestResponse restResponse = getRest()//NOPMD
                     .url(config.getAddress() + "/v1/" + adjustPathForVersionDestroy(path,
                             config.getPrefixPathDepth()))
                     .header("X-Vault-Token", config.getToken())
@@ -562,7 +561,7 @@ public class Logical extends OperationsBase {
             // Make an HTTP request to Vault
             JsonObject kvToUpgrade = new JsonObject().add("options",
                     new JsonObject().add("version", 2));
-            final RestResponse restResponse = new Rest()//NOPMD
+            final RestResponse restResponse = getRest()//NOPMD
                     .url(config.getAddress() + "/v1/sys/mounts/" + (kvPath.replaceAll("/", "")
                             + "/tune"))
                     .header("X-Vault-Token", config.getToken())

--- a/src/main/java/io/github/jopenlibs/vault/api/OperationsBase.java
+++ b/src/main/java/io/github/jopenlibs/vault/api/OperationsBase.java
@@ -2,6 +2,7 @@ package io.github.jopenlibs.vault.api;
 
 import io.github.jopenlibs.vault.VaultConfig;
 import io.github.jopenlibs.vault.VaultException;
+import io.github.jopenlibs.vault.rest.Rest;
 
 
 /**
@@ -45,6 +46,10 @@ public abstract class OperationsBase {
         }
     }
 
+    protected Rest getRest() {
+        return new Rest(config.getHttpClient());
+    }
+
     public interface EndpointOperation<T> {
 
         /**
@@ -64,4 +69,5 @@ public abstract class OperationsBase {
             e.printStackTrace();
         }
     }
+
 }

--- a/src/main/java/io/github/jopenlibs/vault/api/database/Database.java
+++ b/src/main/java/io/github/jopenlibs/vault/api/database/Database.java
@@ -6,7 +6,6 @@ import io.github.jopenlibs.vault.api.OperationsBase;
 import io.github.jopenlibs.vault.json.Json;
 import io.github.jopenlibs.vault.json.JsonObject;
 import io.github.jopenlibs.vault.response.DatabaseResponse;
-import io.github.jopenlibs.vault.rest.Rest;
 import io.github.jopenlibs.vault.rest.RestResponse;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -91,7 +90,7 @@ public class Database extends OperationsBase {
         return retry(attempt -> {
             final String requestJson = roleOptionsToJson(options);
 
-            final RestResponse restResponse = new Rest()//NOPMD
+            final RestResponse restResponse = getRest()//NOPMD
                     .url(String.format("%s/v1/%s/roles/%s", config.getAddress(), this.mountPath,
                             roleName))
                     .header("X-Vault-Token", config.getToken())
@@ -137,7 +136,7 @@ public class Database extends OperationsBase {
      */
     public DatabaseResponse getRole(final String roleName) throws VaultException {
         return retry(attempt -> {
-            final RestResponse restResponse = new Rest()//NOPMD
+            final RestResponse restResponse = getRest()//NOPMD
                     .url(String.format("%s/v1/%s/roles/%s", config.getAddress(), this.mountPath,
                             roleName))
                     .header("X-Vault-Token", config.getToken())
@@ -190,7 +189,7 @@ public class Database extends OperationsBase {
             }
             final String requestJson = jsonObject.toString();
 
-            final RestResponse restResponse = new Rest()//NOPMD
+            final RestResponse restResponse = getRest()//NOPMD
                     .url(String.format("%s/v1/%s/revoke", config.getAddress(), this.mountPath))
                     .header("X-Vault-Token", config.getToken())
                     .header("X-Vault-Namespace", this.nameSpace)
@@ -235,7 +234,7 @@ public class Database extends OperationsBase {
      */
     public DatabaseResponse deleteRole(final String roleName) throws VaultException {
         return retry(attempt -> {
-            final RestResponse restResponse = new Rest()//NOPMD
+            final RestResponse restResponse = getRest()//NOPMD
                     .url(String.format("%s/v1/%s/roles/%s", config.getAddress(), this.mountPath,
                             roleName))
                     .header("X-Vault-Token", config.getToken())
@@ -282,7 +281,7 @@ public class Database extends OperationsBase {
      */
     public DatabaseResponse creds(final String roleName) throws VaultException {
         return retry(attempt -> {
-            final RestResponse restResponse = new Rest()//NOPMD
+            final RestResponse restResponse = getRest()//NOPMD
                     .url(String.format("%s/v1/%s/creds/%s", config.getAddress(), this.mountPath,
                             roleName))
                     .header("X-Vault-Token", config.getToken())

--- a/src/main/java/io/github/jopenlibs/vault/api/pki/Pki.java
+++ b/src/main/java/io/github/jopenlibs/vault/api/pki/Pki.java
@@ -6,7 +6,6 @@ import io.github.jopenlibs.vault.api.OperationsBase;
 import io.github.jopenlibs.vault.json.Json;
 import io.github.jopenlibs.vault.json.JsonObject;
 import io.github.jopenlibs.vault.response.PkiResponse;
-import io.github.jopenlibs.vault.rest.Rest;
 import io.github.jopenlibs.vault.rest.RestResponse;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -117,7 +116,7 @@ public class Pki extends OperationsBase {
         return retry(attempt -> {
             final String requestJson = roleOptionsToJson(options);
 
-            final RestResponse restResponse = new Rest()//NOPMD
+            final RestResponse restResponse = getRest()//NOPMD
                     .url(String.format("%s/v1/%s/roles/%s", config.getAddress(), this.mountPath,
                             roleName))
                     .header("X-Vault-Token", config.getToken())
@@ -165,7 +164,7 @@ public class Pki extends OperationsBase {
      */
     public PkiResponse getRole(final String roleName) throws VaultException {
         return retry(attempt -> {
-            final RestResponse restResponse = new Rest()//NOPMD
+            final RestResponse restResponse = getRest()//NOPMD
                     .url(String.format("%s/v1/%s/roles/%s", config.getAddress(), this.mountPath,
                             roleName))
                     .header("X-Vault-Token", config.getToken())
@@ -217,7 +216,7 @@ public class Pki extends OperationsBase {
                 jsonObject.add("serial_number", serialNumber);
             }
             final String requestJson = jsonObject.toString();
-            final RestResponse restResponse = new Rest()//NOPMD
+            final RestResponse restResponse = getRest()//NOPMD
                     .url(String.format("%s/v1/%s/revoke", config.getAddress(), this.mountPath))
                     .header("X-Vault-Token", config.getToken())
                     .header("X-Vault-Namespace", this.nameSpace)
@@ -262,7 +261,7 @@ public class Pki extends OperationsBase {
      */
     public PkiResponse deleteRole(final String roleName) throws VaultException {
         return retry(attempt -> {
-            final RestResponse restResponse = new Rest()//NOPMD
+            final RestResponse restResponse = getRest()//NOPMD
                     .url(String.format("%s/v1/%s/roles/%s", config.getAddress(), this.mountPath,
                             roleName))
                     .header("X-Vault-Token", config.getToken())
@@ -428,7 +427,7 @@ public class Pki extends OperationsBase {
             String endpoint =
                     (csr == null || csr.isEmpty()) ? "%s/v1/%s/issue/%s" : "%s/v1/%s/sign/%s";
 
-            final RestResponse restResponse = new Rest()//NOPMD
+            final RestResponse restResponse = getRest()//NOPMD
                     .url(String.format(endpoint, config.getAddress(), this.mountPath, roleName))
                     .header("X-Vault-Token", config.getToken())
                     .header("X-Vault-Namespace", this.nameSpace)

--- a/src/test/java/io/github/jopenlibs/vault/ConnectionReUsageTest.java
+++ b/src/test/java/io/github/jopenlibs/vault/ConnectionReUsageTest.java
@@ -1,0 +1,129 @@
+package io.github.jopenlibs.vault;
+
+import io.github.jopenlibs.vault.api.Logical;
+import io.github.jopenlibs.vault.response.LogicalResponse;
+import io.github.jopenlibs.vault.vault.VaultTestUtils;
+import io.github.jopenlibs.vault.vault.mock.MockVault;
+import java.net.Socket;
+import java.net.http.HttpClient;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.eclipse.jetty.io.NetworkTrafficListener;
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.NetworkTrafficServerConnector;
+import org.eclipse.jetty.server.Server;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ConnectionReUsageTest {
+
+    private static final String TOKEN = "token";
+
+    private final NetworkConnectionListener connectionListener = new NetworkConnectionListener();
+
+    private Server vaultServerMock;
+
+    @Before
+    public void setUp() throws Exception {
+        final MockVault mockVault = new MockVault(200, "{\"data\":{\"key\":\"value\"}}");
+        vaultServerMock = initHttpMockVaultWithListener(mockVault, connectionListener);
+        vaultServerMock.start();
+
+        connectionListener.reset();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (vaultServerMock != null) {
+            VaultTestUtils.shutdownMockVault(vaultServerMock);
+        }
+    }
+
+    @Test
+    public void readShouldReuseConnectionAfterSuccessfulRequestByHttp() throws Exception {
+        int readNum = 10;
+
+        HttpClient httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.of(5, ChronoUnit.SECONDS))
+                .build();
+
+        Logical vault = Vault.create(new VaultConfig()
+                .httpClient(httpClient)
+                .address("http://localhost:8999")
+                .token(TOKEN)
+                .readTimeout(1)
+                .engineVersion(1)
+                .build()).logical();
+
+        for (int i = 0; i < readNum; i++) {
+            LogicalResponse resp = vault.read("testing/p1");
+            assertEquals("value", resp.getData().get("key"));
+        }
+
+        int closed = connectionListener.getClosed();
+        int opened = connectionListener.getOpened();
+
+        assertTrue("Too many connections opened: " + opened, opened <= (closed + 1));
+    }
+
+    private static class NetworkConnectionListener implements NetworkTrafficListener {
+
+        private final AtomicInteger opened = new AtomicInteger();
+        private final AtomicInteger closed = new AtomicInteger();
+
+        @Override
+        public void opened(Socket socket) {
+            opened.incrementAndGet();
+        }
+
+        @Override
+        public void closed(Socket socket) {
+            closed.incrementAndGet();
+        }
+
+        @Override
+        public void incoming(Socket socket, ByteBuffer byteBuffer) {
+        }
+
+        @Override
+        public void outgoing(Socket socket, ByteBuffer byteBuffer) {
+        }
+
+        public int getOpened() {
+            return opened.get();
+        }
+
+        public int getClosed() {
+            return closed.get();
+        }
+
+        public void reset() {
+            opened.set(0);
+            closed.set(0);
+        }
+    }
+
+    public Server initHttpMockVaultWithListener(final MockVault mock, NetworkTrafficListener listener) {
+        final Server server = new Server();
+        final HttpConfiguration http = new HttpConfiguration();
+
+        NetworkTrafficServerConnector connector =
+                new NetworkTrafficServerConnector(
+                        server,
+                        new HttpConnectionFactory(http));
+        connector.setNetworkTrafficListener(listener);
+        connector.setPort(8999);
+        server.setConnectors(new Connector[]{connector});
+
+        server.setHandler(mock);
+        return server;
+    }
+}


### PR DESCRIPTION
Hi. 

This address the known issue from the base repo: https://github.com/BetterCloud/vault-java-driver/issues/239.

The idea is to pass a preconfigured HttpClient to VaultConfig and then reuse it by consequent requests done by the same Vault instance. This improves performance and takes full advantages of HTTP/2 protocol by sharing http connections.
The changes cover only user API so far. 

