### PR TITLE
Rest: configure HTTP/1.1 version as default for client instead of request

### DIFF
--- a/src/main/java/io/github/jopenlibs/vault/rest/Rest.java
+++ b/src/main/java/io/github/jopenlibs/vault/rest/Rest.java
@@ -423,7 +423,10 @@ public class Rest {
         if (configuredClient != null) {
             return configuredClient;
         }
-        final var client = HttpClient.newBuilder();
+        final var client = HttpClient.newBuilder()
+                //Stick to HTTP/1.1 by default, coz Vault Agent fails proxying h2c request to https
+                .version(Version.HTTP_1_1);
+
         if (connectTimeoutSeconds != null) {
             client.connectTimeout(Duration.of(connectTimeoutSeconds, ChronoUnit.SECONDS));
         }
@@ -465,7 +468,6 @@ public class Rest {
 
         // Initialize HTTP(S) connection, and set any header values
         var request = HttpRequest.newBuilder()
-                .version(Version.HTTP_1_1)
                 .uri(uri);
 
         headers.forEach(request::header);


### PR DESCRIPTION
This allows HTTP/2 connection negotiation if custom http client is provided.

At first I wanted to remove this forcing of "legacy" HTTP/1 protocol, but couldn't pass integration test for Vault Agent: io.github.jopenlibs.vault.api.VaultAgentTests.testWriteAndReadFromAgent, 
because Vault Agent failed to proxy unsecured HTTP/2 (h2c) connections to secured HTTPS.
Therefore I kept default to HTTP/1.1 for builtin client.