### PR TITLE
Expose CAS option on secret write and version on secret read (K/V 2)

### DIFF
--- a/src/main/java/io/github/jopenlibs/vault/api/Logical.java
+++ b/src/main/java/io/github/jopenlibs/vault/api/Logical.java
@@ -29,7 +29,7 @@ import static io.github.jopenlibs.vault.api.LogicalUtilities.jsonObjectToWriteFr
  */
 public class Logical extends OperationsBase {
 
-    private static final WriteOptions EMPTY_WRITE_OPTIONS = new WriteOptions().build();
+    private static final WriteOptions DEFAULT_WRITE_OPTIONS = new WriteOptions().build();
 
     private String nameSpace;
 
@@ -204,10 +204,10 @@ public class Logical extends OperationsBase {
             throws VaultException {
         if (engineVersionForSecretPath(path).equals(2)) {
             return write(path, nameValuePairs, logicalOperations.writeV2, null,
-                    EMPTY_WRITE_OPTIONS);
+                    DEFAULT_WRITE_OPTIONS);
         } else {
             return write(path, nameValuePairs, logicalOperations.writeV1, null,
-                    EMPTY_WRITE_OPTIONS);
+                    DEFAULT_WRITE_OPTIONS);
         }
     }
 
@@ -243,10 +243,10 @@ public class Logical extends OperationsBase {
             throws VaultException {
         if (engineVersionForSecretPath(path).equals(2)) {
             return write(path, nameValuePairs, logicalOperations.writeV2, wrapTTL,
-                    EMPTY_WRITE_OPTIONS);
+                    DEFAULT_WRITE_OPTIONS);
         } else {
             return write(path, nameValuePairs, logicalOperations.writeV1, wrapTTL,
-                    EMPTY_WRITE_OPTIONS);
+                    DEFAULT_WRITE_OPTIONS);
         }
     }
 

--- a/src/main/java/io/github/jopenlibs/vault/api/Logical.java
+++ b/src/main/java/io/github/jopenlibs/vault/api/Logical.java
@@ -247,9 +247,10 @@ public class Logical extends OperationsBase {
     }
 
     /**
-     * <p>Basic operation to store secrets with write options</p>
+     * <p>Basic operation to store secrets with the ability to specify additional write options
+     * See {@link #write(String, Map, Integer) write} for base behavior
+     * </p>
      *
-     * @see #write(String, Map, Integer)
      * @param path The Vault key value to which to write (e.g. <code>secret/hello</code>)
      * @param nameValuePairs Secret name and value pairs to store under this Vault key (can be
      * @param wrapTTL Time (in seconds) which secret is wrapped

--- a/src/main/java/io/github/jopenlibs/vault/api/Logical.java
+++ b/src/main/java/io/github/jopenlibs/vault/api/Logical.java
@@ -203,9 +203,11 @@ public class Logical extends OperationsBase {
     public LogicalResponse write(final String path, final Map<String, Object> nameValuePairs)
             throws VaultException {
         if (engineVersionForSecretPath(path).equals(2)) {
-            return write(path, nameValuePairs, logicalOperations.writeV2, null, EMPTY_WRITE_OPTIONS);
+            return write(path, nameValuePairs, logicalOperations.writeV2, null,
+                    EMPTY_WRITE_OPTIONS);
         } else {
-            return write(path, nameValuePairs, logicalOperations.writeV1, null, EMPTY_WRITE_OPTIONS);
+            return write(path, nameValuePairs, logicalOperations.writeV1, null,
+                    EMPTY_WRITE_OPTIONS);
         }
     }
 
@@ -240,15 +242,17 @@ public class Logical extends OperationsBase {
             final Integer wrapTTL)
             throws VaultException {
         if (engineVersionForSecretPath(path).equals(2)) {
-            return write(path, nameValuePairs, logicalOperations.writeV2, wrapTTL, EMPTY_WRITE_OPTIONS);
+            return write(path, nameValuePairs, logicalOperations.writeV2, wrapTTL,
+                    EMPTY_WRITE_OPTIONS);
         } else {
-            return write(path, nameValuePairs, logicalOperations.writeV1, wrapTTL, EMPTY_WRITE_OPTIONS);
+            return write(path, nameValuePairs, logicalOperations.writeV1, wrapTTL,
+                    EMPTY_WRITE_OPTIONS);
         }
     }
 
     /**
-     * <p>Basic operation to store secrets with the ability to specify additional write options
-     * See {@link #write(String, Map, Integer) write} for base behavior
+     * <p>Operation to store secrets with the ability to specify additional write options
+     * See {@link #write(String, Map, Integer) write} for common behavior
      * </p>
      *
      * @param path The Vault key value to which to write (e.g. <code>secret/hello</code>)
@@ -256,8 +260,8 @@ public class Logical extends OperationsBase {
      * @param wrapTTL Time (in seconds) which secret is wrapped
      * @param writeOptions Additional options to be used for the write operation
      * @return The response information received from Vault
-     * @throws VaultException If any errors occurs with the REST request, and the maximum number of
-     * retries is exceeded.
+     * @throws VaultException If invalid engine version or if errors occurs with the REST request,
+     *  and the maximum number of retries is exceeded.
      */
     public LogicalResponse write(final String path, final Map<String, Object> nameValuePairs,
             final Integer wrapTTL, final WriteOptions writeOptions)
@@ -275,8 +279,7 @@ public class Logical extends OperationsBase {
 
         return retry(attempt -> {
             JsonObject dataJson = buildJsonFromMap(nameValuePairs);
-            JsonObject optionsJson =
-                    writeOptions.isEmpty() ? null : buildJsonFromMap(writeOptions.getOptionsMap());
+            JsonObject optionsJson = buildJsonFromMap(writeOptions.getOptionsMap());
              // Make an HTTP request to Vault
             final RestResponse restResponse = getRest()//NOPMD
                     .url(config.getAddress() + "/v1/" + adjustPathForReadOrWrite(path,

--- a/src/main/java/io/github/jopenlibs/vault/api/Logical.java
+++ b/src/main/java/io/github/jopenlibs/vault/api/Logical.java
@@ -29,6 +29,8 @@ import static io.github.jopenlibs.vault.api.LogicalUtilities.jsonObjectToWriteFr
  */
 public class Logical extends OperationsBase {
 
+    private static final WriteOptions EMPTY_WRITE_OPTIONS = new WriteOptions().build();
+
     private String nameSpace;
 
     public enum logicalOperations {authentication, deleteV1, deleteV2, destroy, listV1, listV2, readV1, readV2, writeV1, writeV2, unDelete, mount}
@@ -201,9 +203,9 @@ public class Logical extends OperationsBase {
     public LogicalResponse write(final String path, final Map<String, Object> nameValuePairs)
             throws VaultException {
         if (engineVersionForSecretPath(path).equals(2)) {
-            return write(path, nameValuePairs, logicalOperations.writeV2, null);
+            return write(path, nameValuePairs, logicalOperations.writeV2, null, EMPTY_WRITE_OPTIONS);
         } else {
-            return write(path, nameValuePairs, logicalOperations.writeV1, null);
+            return write(path, nameValuePairs, logicalOperations.writeV1, null, EMPTY_WRITE_OPTIONS);
         }
     }
 
@@ -238,47 +240,35 @@ public class Logical extends OperationsBase {
             final Integer wrapTTL)
             throws VaultException {
         if (engineVersionForSecretPath(path).equals(2)) {
-            return write(path, nameValuePairs, logicalOperations.writeV2, wrapTTL);
+            return write(path, nameValuePairs, logicalOperations.writeV2, wrapTTL, EMPTY_WRITE_OPTIONS);
         } else {
-            return write(path, nameValuePairs, logicalOperations.writeV1, wrapTTL);
+            return write(path, nameValuePairs, logicalOperations.writeV1, wrapTTL, EMPTY_WRITE_OPTION);
         }
     }
 
+    public LogicalResponse write(final String path, final Map<String, Object> nameValuePairs,
+            final WriteOptions writeOptions)
+            throws VaultException {
+        if (this.engineVersionForSecretPath(path) != 2) {
+            throw new VaultException("Write options are only supported in KV Engine version 2.");
+        }
+	// TODO handle wrapTTL
+        return write(path, nameValuePairs, logicalOperations.writeV2, null, writeOptions);
+    }
+
     private LogicalResponse write(final String path, final Map<String, Object> nameValuePairs,
-            final logicalOperations operation, final Integer wrapTTL) throws VaultException {
+             final logicalOperations operation, final Integer wrapTTL, final WriteOptions writeOptions)
+             throws VaultException {
 
         return retry(attempt -> {
-            JsonObject requestJson = Json.object();
-            if (nameValuePairs != null) {
-                for (final Map.Entry<String, Object> pair : nameValuePairs.entrySet()) {
-                    final Object value = pair.getValue();
-                    if (value == null) {
-                        requestJson = requestJson.add(pair.getKey(), (String) null);
-                    } else if (value instanceof Boolean) {
-                        requestJson = requestJson.add(pair.getKey(), (Boolean) pair.getValue());
-                    } else if (value instanceof Integer) {
-                        requestJson = requestJson.add(pair.getKey(), (Integer) pair.getValue());
-                    } else if (value instanceof Long) {
-                        requestJson = requestJson.add(pair.getKey(), (Long) pair.getValue());
-                    } else if (value instanceof Float) {
-                        requestJson = requestJson.add(pair.getKey(), (Float) pair.getValue());
-                    } else if (value instanceof Double) {
-                        requestJson = requestJson.add(pair.getKey(), (Double) pair.getValue());
-                    } else if (value instanceof JsonValue) {
-                        requestJson = requestJson.add(pair.getKey(),
-                                (JsonValue) pair.getValue());
-                    } else {
-                        requestJson = requestJson.add(pair.getKey(),
-                                pair.getValue().toString());
-                    }
-                }
-            }
-            // Make an HTTP request to Vault
+            JsonObject dataJson = buildJsonFromMap(nameValuePairs);
+            JsonObject optionsJson = writeOptions.isEmpty() ? null : buildJsonFromMap(writeOptions.getOptionsMap());	
+             // Make an HTTP request to Vault
             final RestResponse restResponse = getRest()//NOPMD
                     .url(config.getAddress() + "/v1/" + adjustPathForReadOrWrite(path,
                             config.getPrefixPathDepth(), operation))
-                    .body(jsonObjectToWriteFromEngineVersion(operation, requestJson).toString()
-                            .getBytes(StandardCharsets.UTF_8))
+                    .body(jsonObjectToWriteFromEngineVersion(operation, dataJson, optionsJson).toString()
+                            .getBytes(StandardCharsets.UTF_8))		
                     .header("X-Vault-Token", config.getToken())
                     .header("X-Vault-Namespace", this.nameSpace)
                     .header("X-Vault-Request", "true")
@@ -607,4 +597,34 @@ public class Logical extends OperationsBase {
     public Integer getEngineVersionForSecretPath(final String path) {
         return this.engineVersionForSecretPath(path);
     }
+
+    private JsonObject buildJsonFromMap(Map<String, Object> nameValuePairs) {
+        JsonObject requestJson = Json.object();
+        if (nameValuePairs != null) {
+            for (final Map.Entry<String, Object> pair : nameValuePairs.entrySet()) {
+                final Object value = pair.getValue();
+                if (value == null) {
+                    requestJson = requestJson.add(pair.getKey(), (String) null);
+                } else if (value instanceof Boolean) {
+                    requestJson = requestJson.add(pair.getKey(), (Boolean) pair.getValue());
+                } else if (value instanceof Integer) {
+                    requestJson = requestJson.add(pair.getKey(), (Integer) pair.getValue());
+                } else if (value instanceof Long) {
+                    requestJson = requestJson.add(pair.getKey(), (Long) pair.getValue());
+                } else if (value instanceof Float) {
+                    requestJson = requestJson.add(pair.getKey(), (Float) pair.getValue());
+                } else if (value instanceof Double) {
+                    requestJson = requestJson.add(pair.getKey(), (Double) pair.getValue());
+                } else if (value instanceof JsonValue) {
+                    requestJson = requestJson.add(pair.getKey(),
+                            (JsonValue) pair.getValue());
+                } else {
+                    requestJson = requestJson.add(pair.getKey(),
+                            pair.getValue().toString());
+                }
+            }
+        }
+        return jsonObject;
+    }
+
 }

--- a/src/main/java/io/github/jopenlibs/vault/api/Logical.java
+++ b/src/main/java/io/github/jopenlibs/vault/api/Logical.java
@@ -242,7 +242,7 @@ public class Logical extends OperationsBase {
         if (engineVersionForSecretPath(path).equals(2)) {
             return write(path, nameValuePairs, logicalOperations.writeV2, wrapTTL, EMPTY_WRITE_OPTIONS);
         } else {
-            return write(path, nameValuePairs, logicalOperations.writeV1, wrapTTL, EMPTY_WRITE_OPTION);
+            return write(path, nameValuePairs, logicalOperations.writeV1, wrapTTL, EMPTY_WRITE_OPTIONS);
         }
     }
 
@@ -252,7 +252,7 @@ public class Logical extends OperationsBase {
         if (this.engineVersionForSecretPath(path) != 2) {
             throw new VaultException("Write options are only supported in KV Engine version 2.");
         }
-	// TODO handle wrapTTL
+        // TODO handle wrapTTL
         return write(path, nameValuePairs, logicalOperations.writeV2, null, writeOptions);
     }
 
@@ -262,13 +262,13 @@ public class Logical extends OperationsBase {
 
         return retry(attempt -> {
             JsonObject dataJson = buildJsonFromMap(nameValuePairs);
-            JsonObject optionsJson = writeOptions.isEmpty() ? null : buildJsonFromMap(writeOptions.getOptionsMap());	
+            JsonObject optionsJson = writeOptions.isEmpty() ? null : buildJsonFromMap(writeOptions.getOptionsMap());
              // Make an HTTP request to Vault
             final RestResponse restResponse = getRest()//NOPMD
                     .url(config.getAddress() + "/v1/" + adjustPathForReadOrWrite(path,
                             config.getPrefixPathDepth(), operation))
                     .body(jsonObjectToWriteFromEngineVersion(operation, dataJson, optionsJson).toString()
-                            .getBytes(StandardCharsets.UTF_8))		
+                            .getBytes(StandardCharsets.UTF_8))
                     .header("X-Vault-Token", config.getToken())
                     .header("X-Vault-Namespace", this.nameSpace)
                     .header("X-Vault-Request", "true")
@@ -599,27 +599,27 @@ public class Logical extends OperationsBase {
     }
 
     private JsonObject buildJsonFromMap(Map<String, Object> nameValuePairs) {
-        JsonObject requestJson = Json.object();
+        JsonObject jsonObject = Json.object();
         if (nameValuePairs != null) {
             for (final Map.Entry<String, Object> pair : nameValuePairs.entrySet()) {
                 final Object value = pair.getValue();
                 if (value == null) {
-                    requestJson = requestJson.add(pair.getKey(), (String) null);
+                    jsonObject = jsonObject.add(pair.getKey(), (String) null);
                 } else if (value instanceof Boolean) {
-                    requestJson = requestJson.add(pair.getKey(), (Boolean) pair.getValue());
+                    jsonObject = jsonObject.add(pair.getKey(), (Boolean) pair.getValue());
                 } else if (value instanceof Integer) {
-                    requestJson = requestJson.add(pair.getKey(), (Integer) pair.getValue());
+                    jsonObject = jsonObject.add(pair.getKey(), (Integer) pair.getValue());
                 } else if (value instanceof Long) {
-                    requestJson = requestJson.add(pair.getKey(), (Long) pair.getValue());
+                    jsonObject = jsonObject.add(pair.getKey(), (Long) pair.getValue());
                 } else if (value instanceof Float) {
-                    requestJson = requestJson.add(pair.getKey(), (Float) pair.getValue());
+                    jsonObject = jsonObject.add(pair.getKey(), (Float) pair.getValue());
                 } else if (value instanceof Double) {
-                    requestJson = requestJson.add(pair.getKey(), (Double) pair.getValue());
+                    jsonObject = jsonObject.add(pair.getKey(), (Double) pair.getValue());
                 } else if (value instanceof JsonValue) {
-                    requestJson = requestJson.add(pair.getKey(),
+                    jsonObject = jsonObject.add(pair.getKey(),
                             (JsonValue) pair.getValue());
                 } else {
-                    requestJson = requestJson.add(pair.getKey(),
+                    jsonObject = jsonObject.add(pair.getKey(),
                             pair.getValue().toString());
                 }
             }

--- a/src/main/java/io/github/jopenlibs/vault/api/LogicalUtilities.java
+++ b/src/main/java/io/github/jopenlibs/vault/api/LogicalUtilities.java
@@ -220,5 +220,4 @@ public class LogicalUtilities {
             return jsonObject;
         }
     }
-
 }

--- a/src/main/java/io/github/jopenlibs/vault/api/LogicalUtilities.java
+++ b/src/main/java/io/github/jopenlibs/vault/api/LogicalUtilities.java
@@ -198,10 +198,12 @@ public class LogicalUtilities {
     }
 
     /**
-     * In version two, when writing a secret, the JSONObject must be nested with "data" as the key.
+     * In version two, when writing a secret, the JSONObject must be nested with "data" as the key
+     * and an "options" key may be optionally provided
      *
      * @param operation The operation being performed, e.g. writeV1, or writeV2.
      * @param jsonObject The jsonObject that is going to be written.
+     * @param optionsJsonObject The options jsonObject that is going to be written or null if none
      * @return This jsonObject mutated for the operation.
      */
     public static JsonObject jsonObjectToWriteFromEngineVersion(

--- a/src/main/java/io/github/jopenlibs/vault/api/LogicalUtilities.java
+++ b/src/main/java/io/github/jopenlibs/vault/api/LogicalUtilities.java
@@ -212,7 +212,7 @@ public class LogicalUtilities {
         if (operation.equals(Logical.logicalOperations.writeV2)) {
             final JsonObject wrappedJson = new JsonObject();
             wrappedJson.add("data", jsonObject);
-            if (null != optionsJsonObject) {
+            if (!optionsJsonObject.isEmpty()) {
                 wrappedJson.add("options", optionsJsonObject);
             }
             return wrappedJson;

--- a/src/main/java/io/github/jopenlibs/vault/api/LogicalUtilities.java
+++ b/src/main/java/io/github/jopenlibs/vault/api/LogicalUtilities.java
@@ -205,13 +205,18 @@ public class LogicalUtilities {
      * @return This jsonObject mutated for the operation.
      */
     public static JsonObject jsonObjectToWriteFromEngineVersion(
-            final Logical.logicalOperations operation, final JsonObject jsonObject) {
+            final Logical.logicalOperations operation, final JsonObject jsonObject,
+            final JsonObject optionsJsonObject) {
         if (operation.equals(Logical.logicalOperations.writeV2)) {
             final JsonObject wrappedJson = new JsonObject();
             wrappedJson.add("data", jsonObject);
+            if (null != optionsJsonObject) {
+                wrappedJson.add("options", optionsJsonObject);
+            }
             return wrappedJson;
         } else {
             return jsonObject;
         }
     }
+
 }

--- a/src/main/java/io/github/jopenlibs/vault/api/WriteOptions.java
+++ b/src/main/java/io/github/jopenlibs/vault/api/WriteOptions.java
@@ -1,0 +1,37 @@
+package com.bettercloud.vault.api;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class WriteOptions {
+
+    public static final String CHECK_AND_SET_KEY = "cas";
+
+    private final Map<String, Object> options = new HashMap<>();
+
+    public WriteOptions checkAndSet(Long version) {
+        return setOption(CHECK_AND_SET_KEY, version);
+    }
+
+    public WriteOptions setOption(String name, Object value) {
+        options.put(name, value);
+        return this;
+    }
+
+    public WriteOptions build() {
+        return this;
+    }
+
+    public Map<String, Object> getOptionsMap() {
+        return Collections.unmodifiableMap(options);
+    }
+
+    public boolean isEmpty() {
+        return options.isEmpty();
+    }
+
+    public static WriteOptions emptyOptions() {
+        return new WriteOptions().build();
+    }
+}

--- a/src/main/java/io/github/jopenlibs/vault/api/WriteOptions.java
+++ b/src/main/java/io/github/jopenlibs/vault/api/WriteOptions.java
@@ -31,7 +31,4 @@ public class WriteOptions {
         return options.isEmpty();
     }
 
-    public static WriteOptions emptyOptions() {
-        return new WriteOptions().build();
-    }
 }

--- a/src/main/java/io/github/jopenlibs/vault/api/WriteOptions.java
+++ b/src/main/java/io/github/jopenlibs/vault/api/WriteOptions.java
@@ -1,4 +1,4 @@
-package com.bettercloud.vault.api;
+package io.github.jopenlibs.vault.api;
 
 import java.util.Collections;
 import java.util.HashMap;

--- a/src/main/java/io/github/jopenlibs/vault/api/WriteOptions.java
+++ b/src/main/java/io/github/jopenlibs/vault/api/WriteOptions.java
@@ -4,29 +4,57 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Options that may be set as part of K/V V2 write operation.
+ * Construct instances of this class using a builder pattern, calling setter methods for each
+ * value and then terminating with a call to build().
+ */
 public class WriteOptions {
 
     public static final String CHECK_AND_SET_KEY = "cas";
 
     private final Map<String, Object> options = new HashMap<>();
 
+    /**
+     * Enable check and set (CAS) option
+     * @param version current version of the secret
+     * @return updated options ready for additional builder-pattern calls or else finalization
+     * with the build() method
+     */
     public WriteOptions checkAndSet(Long version) {
         return setOption(CHECK_AND_SET_KEY, version);
     }
 
+    /**
+     * Set an option to a value
+     * @param name option name
+     * @param value option value
+     * @return updated options ready for additional builder-pattern calls or else finalization
+     * with the build() method
+     */
     public WriteOptions setOption(String name, Object value) {
         options.put(name, value);
         return this;
     }
 
+    /**
+     * Finalize the options (terminating method in the builder pattern)
+     * @return this object, with all available config options parsed and loaded
+     */
     public WriteOptions build() {
         return this;
     }
 
+    /**
+     * @return options as a Map
+     */
     public Map<String, Object> getOptionsMap() {
         return Collections.unmodifiableMap(options);
     }
 
+    /**
+     * @return true if no options are set, false otherwise
+     */
     public boolean isEmpty() {
         return options.isEmpty();
     }

--- a/src/main/java/io/github/jopenlibs/vault/api/WriteOptions.java
+++ b/src/main/java/io/github/jopenlibs/vault/api/WriteOptions.java
@@ -5,7 +5,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Options that may be set as part of K/V V2 write operation.
+ * Additional options that may be set as part of K/V V2 write operation.
  * Construct instances of this class using a builder pattern, calling setter methods for each
  * value and then terminating with a call to build().
  */

--- a/src/main/java/io/github/jopenlibs/vault/response/DataMetadata.java
+++ b/src/main/java/io/github/jopenlibs/vault/response/DataMetadata.java
@@ -1,0 +1,29 @@
+package com.bettercloud.vault.response;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class DataMetadata {
+
+    public static final String VERSION_KEY = "version";
+
+    private final Map<String, String> metadataMap;
+
+    public DataMetadata(Map<String, String> metadataMap) {
+        this.metadataMap = metadataMap;
+    }
+
+    public Long getVersion() {
+        final String versionString = metadataMap.get(VERSION_KEY);
+        return (null != versionString) ? Long.valueOf(versionString) : null;
+    }
+
+    public Map<String, String> getMetadataMap() {
+        return Collections.unmodifiableMap(metadataMap);
+    }
+
+    public boolean isEmpty() {
+        return metadataMap.isEmpty();
+    }
+
+}

--- a/src/main/java/io/github/jopenlibs/vault/response/DataMetadata.java
+++ b/src/main/java/io/github/jopenlibs/vault/response/DataMetadata.java
@@ -1,4 +1,4 @@
-package com.bettercloud.vault.response;
+package io.github.jopenlibs.vault.response;
 
 import java.util.Collections;
 import java.util.Map;

--- a/src/main/java/io/github/jopenlibs/vault/response/DataMetadata.java
+++ b/src/main/java/io/github/jopenlibs/vault/response/DataMetadata.java
@@ -3,6 +3,9 @@ package io.github.jopenlibs.vault.response;
 import java.util.Collections;
 import java.util.Map;
 
+/**
+ * Container for metadata that can be returned with a logical operation response
+ */
 public class DataMetadata {
 
     public static final String VERSION_KEY = "version";

--- a/src/main/java/io/github/jopenlibs/vault/response/LogicalResponse.java
+++ b/src/main/java/io/github/jopenlibs/vault/response/LogicalResponse.java
@@ -25,7 +25,7 @@ public class LogicalResponse extends VaultResponse {
     private WrapResponse wrapResponse;
     private Boolean renewable;
     private Long leaseDuration;
-    private final Map<String, String> metadata = new HashMap<>();
+    private final Map<String, String> dataMetadata = new HashMap<>();
 
     /**
      * @param restResponse The raw HTTP response from Vault.
@@ -63,13 +63,16 @@ public class LogicalResponse extends VaultResponse {
         return leaseDuration;
     }
 
-
     public WrapResponse getWrapResponse() {
         return wrapResponse;
     }
 
     public Map<String, String> getMetadata() {
         return metadata;
+    }
+    
+    public DataMetadata getDataMetadata() {
+        return new DataMetadata(dataMetadata);
     }
 
     private void parseMetadataFields() {
@@ -102,7 +105,7 @@ public class LogicalResponse extends VaultResponse {
             JsonValue metadataValue = jsonObject.get("metadata");
             if (null != metadataValue) {
                 JsonObject metadataObject = metadataValue.asObject();
-                parseJsonIntoMap(metadataObject, metadata);
+                parseJsonIntoMap(metadataObject, dataMetadata);
             }
 
             // For list operations convert the array of keys to a list of values

--- a/src/main/java/io/github/jopenlibs/vault/response/LogicalResponse.java
+++ b/src/main/java/io/github/jopenlibs/vault/response/LogicalResponse.java
@@ -97,16 +97,15 @@ public class LogicalResponse extends VaultResponse {
             JsonObject jsonObject = Json.parse(jsonString).asObject();
             if (operation.equals(Logical.logicalOperations.readV2)) {
                 jsonObject = jsonObject.get("data").asObject();
+
+                JsonValue metadataValue = jsonObject.get("metadata");
+                if (null != metadataValue) {
+                    parseJsonIntoMap(metadataValue.asObject(), dataMetadata);
+                }
             }
             data = new HashMap<>();
             dataObject = jsonObject.get("data").asObject();
             parseJsonIntoMap(dataObject, data);
-
-            JsonValue metadataValue = jsonObject.get("metadata");
-            if (null != metadataValue) {
-                JsonObject metadataObject = metadataValue.asObject();
-                parseJsonIntoMap(metadataObject, dataMetadata);
-            }
 
             // For list operations convert the array of keys to a list of values
             if (operation.equals(Logical.logicalOperations.listV1) || operation.equals(

--- a/src/main/java/io/github/jopenlibs/vault/response/LogicalResponse.java
+++ b/src/main/java/io/github/jopenlibs/vault/response/LogicalResponse.java
@@ -67,10 +67,6 @@ public class LogicalResponse extends VaultResponse {
         return wrapResponse;
     }
 
-    public Map<String, String> getMetadata() {
-        return metadata;
-    }
-    
     public DataMetadata getDataMetadata() {
         return new DataMetadata(dataMetadata);
     }

--- a/src/main/java/io/github/jopenlibs/vault/response/LogicalResponse.java
+++ b/src/main/java/io/github/jopenlibs/vault/response/LogicalResponse.java
@@ -25,6 +25,7 @@ public class LogicalResponse extends VaultResponse {
     private WrapResponse wrapResponse;
     private Boolean renewable;
     private Long leaseDuration;
+    private final Map<String, String> metadata = new HashMap<>();
 
     /**
      * @param restResponse The raw HTTP response from Vault.
@@ -62,8 +63,13 @@ public class LogicalResponse extends VaultResponse {
         return leaseDuration;
     }
 
+
     public WrapResponse getWrapResponse() {
         return wrapResponse;
+    }
+
+    public Map<String, String> getMetadata() {
+        return metadata;
     }
 
     private void parseMetadataFields() {
@@ -91,16 +97,14 @@ public class LogicalResponse extends VaultResponse {
             }
             data = new HashMap<>();
             dataObject = jsonObject.get("data").asObject();
-            for (final JsonObject.Member member : dataObject) {
-                final JsonValue jsonValue = member.getValue();
-                if (jsonValue == null || jsonValue.isNull()) {
-                    continue;
-                } else if (jsonValue.isString()) {
-                    data.put(member.getName(), jsonValue.asString());
-                } else {
-                    data.put(member.getName(), jsonValue.toString());
-                }
+            parseJsonIntoMap(dataObject, data);
+
+            JsonValue metadataValue = jsonObject.get("metadata");
+            if (null != metadataValue) {
+                JsonObject metadataObject = metadataValue.asObject();
+                parseJsonIntoMap(metadataObject, metadata);
             }
+
             // For list operations convert the array of keys to a list of values
             if (operation.equals(Logical.logicalOperations.listV1) || operation.equals(
                     Logical.logicalOperations.listV2)) {
@@ -119,4 +123,18 @@ public class LogicalResponse extends VaultResponse {
         } catch (Exception ignored) {
         }
     }
+
+    private void parseJsonIntoMap(JsonObject jsonObject, Map<String, String> map) {
+        for (final JsonObject.Member member : jsonObject) {
+            final JsonValue jsonValue = member.getValue();
+            if (jsonValue == null || jsonValue.isNull()) {
+                continue;
+            } else if (jsonValue.isString()) {
+                map.put(member.getName(), jsonValue.asString());
+            } else {
+                map.put(member.getName(), jsonValue.toString());
+            }
+        }
+    }
+
 }

--- a/src/main/java/io/github/jopenlibs/vault/response/LogicalResponse.java
+++ b/src/main/java/io/github/jopenlibs/vault/response/LogicalResponse.java
@@ -93,7 +93,6 @@ public class LogicalResponse extends VaultResponse {
             JsonObject jsonObject = Json.parse(jsonString).asObject();
             if (operation.equals(Logical.logicalOperations.readV2)) {
                 jsonObject = jsonObject.get("data").asObject();
-
                 JsonValue metadataValue = jsonObject.get("metadata");
                 if (null != metadataValue) {
                     parseJsonIntoMap(metadataValue.asObject(), dataMetadata);
@@ -122,7 +121,7 @@ public class LogicalResponse extends VaultResponse {
         }
     }
 
-    private void parseJsonIntoMap(JsonObject jsonObject, Map<String, String> map) {
+    private void parseJsonIntoMap(final JsonObject jsonObject, final Map<String, String> map) {
         for (final JsonObject.Member member : jsonObject) {
             final JsonValue jsonValue = member.getValue();
             if (jsonValue == null || jsonValue.isNull()) {

--- a/src/test-integration/java/io/github/jopenlibs/vault/api/LogicalTests.java
+++ b/src/test-integration/java/io/github/jopenlibs/vault/api/LogicalTests.java
@@ -1,5 +1,6 @@
 package io.github.jopenlibs.vault.api;
 
+
 import io.github.jopenlibs.vault.Vault;
 import io.github.jopenlibs.vault.VaultConfig;
 import io.github.jopenlibs.vault.VaultException;
@@ -20,6 +21,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import static junit.framework.Assert.assertNotNull;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertNotNull;
@@ -67,6 +69,99 @@ public class LogicalTests {
 
         final String valueRead = vault.logical().read(pathToRead).getData().get("value");
         assertEquals(value, valueRead);
+    }
+
+    @Test
+    public void testWriteWithCheckAndSetAndReadWithDataMetadata() throws VaultException {
+        final String secretPath = "secret/checkAndSet";
+
+        final Vault vault = container.getRootVault();
+
+        final String value = "firstWorld";
+        final Map<String, Object> testData = new HashMap<>();
+        testData.put("value", value);
+
+        WriteOptions writeOptions = new WriteOptions().checkAndSet(0L).build();
+        vault.logical().write(secretPath, testData, writeOptions);
+
+        final LogicalResponse readResponse = vault.logical().read(secretPath);
+        final String valueRead = readResponse.getData().get("value");
+        assertEquals(value, valueRead);
+        final DataMetadata dataMetadata = readResponse.getDataMetadata();
+        assertNotNull(dataMetadata);
+        assertFalse(dataMetadata.isEmpty());
+        final Long secretVersion = dataMetadata.getVersion();
+        assertNotNull(secretVersion);
+        assertEquals(1L, secretVersion.longValue());
+    }
+
+    @Test
+    public void testWriteWithCheckAndSetWrongCreateVersion() throws VaultException {
+        final String secretPath = "secret/checkAndSetWrongVersion";
+
+        final Vault vault = container.getRootVault();
+
+        final String value = "firstWorld";
+        final Map<String, Object> testData = new HashMap<>();
+        testData.put("value", value);
+
+        WriteOptions writeOptions = new WriteOptions().checkAndSet(1L).build();
+        LogicalResponse writeResponse = vault.logical().write(secretPath, testData, writeOptions);
+        assertEquals(400, writeResponse.getRestResponse().getStatus());
+    }
+
+    @Test
+    public void tesUpdateWithCheckAndSetAndReadWithDataMetadata() throws VaultException {
+        final String secretPath = "secret/checkAndSetUpdate";
+
+        final Vault vault = container.getRootVault();
+
+        final String createValue = "firstWorld";
+        final Map<String, Object> testDataCreate = new HashMap<>();
+        testDataCreate.put("value", createValue);
+
+        LogicalResponse createResponse = vault.logical().write(secretPath, testDataCreate);
+        assertEquals(200, createResponse.getRestResponse().getStatus());
+
+        final String updateValue = "secondWorld";
+        final Map<String, Object> testDataUpdate = new HashMap<>();
+        testDataUpdate.put("value", updateValue);
+
+        WriteOptions updateOptions = new WriteOptions().checkAndSet(1L).build();
+        LogicalResponse updateResponse = vault.logical().write(secretPath, testDataUpdate, updateOptions);
+        assertEquals(200, updateResponse.getRestResponse().getStatus());
+
+        final LogicalResponse readResponse = vault.logical().read(secretPath);
+        final String valueRead = readResponse.getData().get("value");
+        assertEquals(updateValue, valueRead);
+        final DataMetadata dataMetadata = readResponse.getDataMetadata();
+        assertNotNull(dataMetadata);
+        assertFalse(dataMetadata.isEmpty());
+        final Long secretVersion = dataMetadata.getVersion();
+        assertNotNull(secretVersion);
+        assertEquals(2L, secretVersion.longValue());
+    }
+
+    @Test
+    public void testWriteWithCheckAndSetWrongUpdateVersion() throws VaultException {
+        final String secretPath = "secret/checkAndSetUpdateWrongVersion";
+
+        final Vault vault = container.getRootVault();
+
+        final String createValue = "firstWorld";
+        final Map<String, Object> testDataCreate = new HashMap<>();
+        testDataCreate.put("value", createValue);
+
+        LogicalResponse createResponse = vault.logical().write(secretPath, testDataCreate);
+        assertEquals(200, createResponse.getRestResponse().getStatus());
+
+        final String updateValue = "secondWorld";
+        final Map<String, Object> testDataUpdate = new HashMap<>();
+        testDataUpdate.put("value", updateValue);
+
+        WriteOptions updateOptions = new WriteOptions().checkAndSet(2L).build();
+        LogicalResponse updateResponse = vault.logical().write(secretPath, testDataUpdate, updateOptions);
+        assertEquals(400, updateResponse.getRestResponse().getStatus());
     }
 
     /**

--- a/src/test-integration/java/io/github/jopenlibs/vault/api/LogicalTests.java
+++ b/src/test-integration/java/io/github/jopenlibs/vault/api/LogicalTests.java
@@ -1,10 +1,10 @@
 package io.github.jopenlibs.vault.api;
 
-
 import io.github.jopenlibs.vault.Vault;
 import io.github.jopenlibs.vault.VaultConfig;
 import io.github.jopenlibs.vault.VaultException;
 import io.github.jopenlibs.vault.response.AuthResponse;
+import io.github.jopenlibs.vault.response.DataMetadata;
 import io.github.jopenlibs.vault.response.LogicalResponse;
 import io.github.jopenlibs.vault.response.WrapResponse;
 import io.github.jopenlibs.vault.util.VaultContainer;
@@ -21,7 +21,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import static junit.framework.Assert.assertNotNull;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertNotNull;

--- a/src/test-integration/java/io/github/jopenlibs/vault/api/LogicalTests.java
+++ b/src/test-integration/java/io/github/jopenlibs/vault/api/LogicalTests.java
@@ -89,6 +89,8 @@ public class LogicalTests {
         final DataMetadata dataMetadata = readResponse.getDataMetadata();
         assertNotNull(dataMetadata);
         assertFalse(dataMetadata.isEmpty());
+        assertFalse(dataMetadata.getMetadataMap().isEmpty());
+        assertTrue(dataMetadata.getMetadataMap().containsKey(DataMetadata.VERSION_KEY));
         final Long secretVersion = dataMetadata.getVersion();
         assertNotNull(secretVersion);
         assertEquals(1L, secretVersion.longValue());

--- a/src/test-integration/java/io/github/jopenlibs/vault/api/LogicalTests.java
+++ b/src/test-integration/java/io/github/jopenlibs/vault/api/LogicalTests.java
@@ -81,7 +81,7 @@ public class LogicalTests {
         testData.put("value", value);
 
         WriteOptions writeOptions = new WriteOptions().checkAndSet(0L).build();
-        vault.logical().write(secretPath, testData, writeOptions);
+        vault.logical().write(secretPath, testData, null, writeOptions);
 
         final LogicalResponse readResponse = vault.logical().read(secretPath);
         final String valueRead = readResponse.getData().get("value");
@@ -105,7 +105,8 @@ public class LogicalTests {
         testData.put("value", value);
 
         WriteOptions writeOptions = new WriteOptions().checkAndSet(1L).build();
-        LogicalResponse writeResponse = vault.logical().write(secretPath, testData, writeOptions);
+        LogicalResponse writeResponse =
+                vault.logical().write(secretPath, testData, null, writeOptions);
         assertEquals(400, writeResponse.getRestResponse().getStatus());
     }
 
@@ -127,7 +128,8 @@ public class LogicalTests {
         testDataUpdate.put("value", updateValue);
 
         WriteOptions updateOptions = new WriteOptions().checkAndSet(1L).build();
-        LogicalResponse updateResponse = vault.logical().write(secretPath, testDataUpdate, updateOptions);
+        LogicalResponse updateResponse =
+                vault.logical().write(secretPath, testDataUpdate, null, updateOptions);
         assertEquals(200, updateResponse.getRestResponse().getStatus());
 
         final LogicalResponse readResponse = vault.logical().read(secretPath);
@@ -159,7 +161,8 @@ public class LogicalTests {
         testDataUpdate.put("value", updateValue);
 
         WriteOptions updateOptions = new WriteOptions().checkAndSet(2L).build();
-        LogicalResponse updateResponse = vault.logical().write(secretPath, testDataUpdate, updateOptions);
+        LogicalResponse updateResponse =
+                vault.logical().write(secretPath, testDataUpdate, null, updateOptions);
         assertEquals(400, updateResponse.getRestResponse().getStatus());
     }
 

--- a/src/test/java/io/github/jopenlibs/vault/LogicalUtilitiesTests.java
+++ b/src/test/java/io/github/jopenlibs/vault/LogicalUtilitiesTests.java
@@ -119,12 +119,19 @@ public class LogicalUtilitiesTests {
     public void jsonObjectToWriteFromEngineVersionTests() {
         JsonObject jsonObjectV2 = new JsonObject().add("test", "test");
         JsonObject jsonObjectFromEngineVersionV2 = LogicalUtilities.jsonObjectToWriteFromEngineVersion(
-                Logical.logicalOperations.writeV2, jsonObjectV2);
+                Logical.logicalOperations.writeV2, jsonObjectV2, null);
         Assert.assertEquals(jsonObjectFromEngineVersionV2.get("data"), jsonObjectV2);
+        Assert.assertNull(jsonObjectFromEngineVersionV2.get("options"));
+
+        JsonObject optionsJsonObject = new JsonObject().add("cas", "0");
+        JsonObject jsonObjectFromEngineVersion2WithOptions = LogicalUtilities.jsonObjectToWriteFromEngineVersion(
+                Logical.logicalOperations.writeV2, jsonObjectV2, optionsJsonObject);
+        Assert.assertEquals(jsonObjectFromEngineVersion2WithOptions.get("data"), jsonObjectV2);
+        Assert.assertEquals(jsonObjectFromEngineVersion2WithOptions.get("options"), optionsJsonObject);
 
         JsonObject jsonObjectV1 = new JsonObject().add("test", "test");
         JsonObject jsonObjectFromEngineVersionV1 = LogicalUtilities.jsonObjectToWriteFromEngineVersion(
-                Logical.logicalOperations.writeV1, jsonObjectV1);
+                Logical.logicalOperations.writeV1, jsonObjectV1, null);
         Assert.assertNull(jsonObjectFromEngineVersionV1.get("data"));
     }
 

--- a/src/test/java/io/github/jopenlibs/vault/LogicalUtilitiesTests.java
+++ b/src/test/java/io/github/jopenlibs/vault/LogicalUtilitiesTests.java
@@ -124,8 +124,12 @@ public class LogicalUtilitiesTests {
         Assert.assertNull(jsonObjectFromEngineVersionV2.get("options"));
 
         JsonObject optionsJsonObject = new JsonObject().add("cas", "0");
+<<<<<<< HEAD:src/test/java/io/github/jopenlibs/vault/LogicalUtilitiesTests.java
         JsonObject jsonObjectFromEngineVersion2WithOptions = LogicalUtilities.jsonObjectToWriteFromEngineVersion(
                 Logical.logicalOperations.writeV2, jsonObjectV2, optionsJsonObject);
+=======
+        JsonObject jsonObjectFromEngineVersion2WithOptions = LogicalUtilities.jsonObjectToWriteFromEngineVersion(Logical.logicalOperations.writeV2, jsonObjectV2, optionsJsonObject);
+>>>>>>> 4ab63c8 (Improve api and add tests):src/test/java/com/bettercloud/vault/LogicalUtilitiesTests.java
         Assert.assertEquals(jsonObjectFromEngineVersion2WithOptions.get("data"), jsonObjectV2);
         Assert.assertEquals(jsonObjectFromEngineVersion2WithOptions.get("options"), optionsJsonObject);
 

--- a/src/test/java/io/github/jopenlibs/vault/LogicalUtilitiesTests.java
+++ b/src/test/java/io/github/jopenlibs/vault/LogicalUtilitiesTests.java
@@ -119,20 +119,21 @@ public class LogicalUtilitiesTests {
     public void jsonObjectToWriteFromEngineVersionTests() {
         JsonObject jsonObjectV2 = new JsonObject().add("test", "test");
         JsonObject jsonObjectFromEngineVersionV2 = LogicalUtilities.jsonObjectToWriteFromEngineVersion(
-                Logical.logicalOperations.writeV2, jsonObjectV2, null);
+                Logical.logicalOperations.writeV2, jsonObjectV2, new JsonObject());
         Assert.assertEquals(jsonObjectFromEngineVersionV2.get("data"), jsonObjectV2);
         Assert.assertNull(jsonObjectFromEngineVersionV2.get("options"));
 
-        JsonObject optionsJsonObject = new JsonObject().add("cas", "0");
+        JsonObject casWriteOptions = new JsonObject().add("cas", "0");
         JsonObject jsonObjectFromEngineVersion2WithOptions = LogicalUtilities.jsonObjectToWriteFromEngineVersion(
-                Logical.logicalOperations.writeV2, jsonObjectV2, optionsJsonObject);
+                Logical.logicalOperations.writeV2, jsonObjectV2, casWriteOptions);
         Assert.assertEquals(jsonObjectFromEngineVersion2WithOptions.get("data"), jsonObjectV2);
-        Assert.assertEquals(jsonObjectFromEngineVersion2WithOptions.get("options"), optionsJsonObject);
+        Assert.assertEquals(jsonObjectFromEngineVersion2WithOptions.get("options"), casWriteOptions);
 
         JsonObject jsonObjectV1 = new JsonObject().add("test", "test");
         JsonObject jsonObjectFromEngineVersionV1 = LogicalUtilities.jsonObjectToWriteFromEngineVersion(
-                Logical.logicalOperations.writeV1, jsonObjectV1, null);
+                Logical.logicalOperations.writeV1, jsonObjectV1, new JsonObject());
         Assert.assertNull(jsonObjectFromEngineVersionV1.get("data"));
+        Assert.assertNull(jsonObjectFromEngineVersionV2.get("options"));
     }
 
 }

--- a/src/test/java/io/github/jopenlibs/vault/LogicalUtilitiesTests.java
+++ b/src/test/java/io/github/jopenlibs/vault/LogicalUtilitiesTests.java
@@ -124,12 +124,8 @@ public class LogicalUtilitiesTests {
         Assert.assertNull(jsonObjectFromEngineVersionV2.get("options"));
 
         JsonObject optionsJsonObject = new JsonObject().add("cas", "0");
-<<<<<<< HEAD:src/test/java/io/github/jopenlibs/vault/LogicalUtilitiesTests.java
         JsonObject jsonObjectFromEngineVersion2WithOptions = LogicalUtilities.jsonObjectToWriteFromEngineVersion(
                 Logical.logicalOperations.writeV2, jsonObjectV2, optionsJsonObject);
-=======
-        JsonObject jsonObjectFromEngineVersion2WithOptions = LogicalUtilities.jsonObjectToWriteFromEngineVersion(Logical.logicalOperations.writeV2, jsonObjectV2, optionsJsonObject);
->>>>>>> 4ab63c8 (Improve api and add tests):src/test/java/com/bettercloud/vault/LogicalUtilitiesTests.java
         Assert.assertEquals(jsonObjectFromEngineVersion2WithOptions.get("data"), jsonObjectV2);
         Assert.assertEquals(jsonObjectFromEngineVersion2WithOptions.get("options"), optionsJsonObject);
 


### PR DESCRIPTION
* Expose the the "check and set" (CAS) option for optimistic locking behavior on secret write operation
** https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#cas
* Expose the secret version from the metadata block on secret read operation response so it can be used for CAS
** https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#read-secret-version

Port of [PR 230](https://github.com/BetterCloud/vault-java-driver/pull/230) on [BetterCloud:master](https://github.com/BetterCloud/vault-java-driver/tree/master)