### PR TITLE
fix: use TLS protocol alias to enable TLS 1.3 negotiation

### DIFF
--- a/src/main/java/io/github/jopenlibs/vault/SslConfig.java
+++ b/src/main/java/io/github/jopenlibs/vault/SslConfig.java
@@ -578,7 +578,7 @@ public class SslConfig implements Serializable {
         }
 
         try {
-            final SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
+            final SSLContext sslContext = SSLContext.getInstance("TLSv1.3");
             sslContext.init(keyManagers, trustManagers, null);
             return sslContext;
         } catch (NoSuchAlgorithmException | KeyManagementException e) {
@@ -643,7 +643,7 @@ public class SslConfig implements Serializable {
                 keyManagers = keyManagerFactory.getKeyManagers();
             }
 
-            final SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
+            final SSLContext sslContext = SSLContext.getInstance("TLSv1.3");
             sslContext.init(keyManagers, trustManagers, null);
             return sslContext;
         } catch (CertificateException | IOException | NoSuchAlgorithmException | KeyStoreException |

--- a/src/main/java/io/github/jopenlibs/vault/rest/Rest.java
+++ b/src/main/java/io/github/jopenlibs/vault/rest/Rest.java
@@ -78,7 +78,7 @@ public class Rest {
 
     static {
         try {
-            DISABLED_SSL_CONTEXT = SSLContext.getInstance("TLSv1.2");
+            DISABLED_SSL_CONTEXT = SSLContext.getInstance("TLSv1.3");
             DISABLED_SSL_CONTEXT.init(null, new TrustManager[]{new X509ExtendedTrustManager() {
                 @Override
                 public void checkClientTrusted(X509Certificate[] chain, String authType,

--- a/src/test/java/io/github/jopenlibs/vault/SSLTests.java
+++ b/src/test/java/io/github/jopenlibs/vault/SSLTests.java
@@ -12,7 +12,10 @@ import java.util.HashMap;
 import org.eclipse.jetty.server.Server;
 import org.junit.Test;
 
+import java.util.Arrays;
+import javax.net.ssl.SSLContext;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Unit tests for the Vault driver, having no dependency on an actual Vault server instance being
@@ -278,5 +281,16 @@ public class SSLTests {
 
         VaultTestUtils.shutdownMockVault(server);
     }
+
+    @Test
+    public void testSslContextFromPemSupportsTls13() throws Exception {
+        final SslConfig sslConfig = new SslConfig().pemResource("/cert.pem").build();
+        final SSLContext sslContext = sslConfig.getSslContext();
+        final java.util.List<String> supported = Arrays.asList(
+                sslContext.getSupportedSSLParameters().getProtocols());
+        assertTrue("SSLContext from PEM must support TLSv1.3", supported.contains("TLSv1.3"));
+        assertTrue("SSLContext from PEM must support TLSv1.2", supported.contains("TLSv1.2"));
+    }
+
 
 }


### PR DESCRIPTION
## Problem

`SSLContext.getInstance("TLSv1.2")` hard-caps TLS negotiation at 1.2. Connections to Vault servers with `tls_min_version = "tls13"` fail:

```
javax.net.ssl.SSLHandshakeException: Received fatal alert: protocol_version
```

fixes #76 

## Fix

Replace `"TLSv1.2"` → `"TLSv1.3"` in three places:

| File | Method |
|------|--------|
| `rest/Rest.java` | `DISABLED_SSL_CONTEXT` static initializer |
| `SslConfig.java` | `buildSslContextFromJks()` |
| `SslConfig.java` | `buildSslContextFromPem()` |

`SSLContext.getInstance("TLSv1.3")` on Java 11+ (SunJSSE) enables `[TLSv1.3, TLSv1.2]` by default, which also drops the insecure TLS 1.0/1.1 protocols that `"TLS"` would otherwise include.

## Test

Added `testSslContextFromPemSupportsTls13` to `SSLTests` asserting that `SslConfig` built with a PEM cert produces an `SSLContext` supporting both TLSv1.2 and TLSv1.3.